### PR TITLE
feat: add listModels() functions for openai, ollama and anthropic

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ npm install fluent-ai
 
 fluent-ai includes support for multiple AI providers and modalities.
 
-| Provider  | chat               | embedding          | image              |
-| --------- | ------------------ | ------------------ | ------------------ |
-| anthropic | :white_check_mark: |                    |                    |
-| fal       |                    |                    | :white_check_mark: |
-| ollama    | :white_check_mark: | :white_check_mark: |
-| openai    | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| voyageai  |                    | :white_check_mark: |                    |
+| Provider  | chat               | embedding          | image              | listModels         |
+| --------- | ------------------ | ------------------ | ------------------ | ------------------ |
+| anthropic | :white_check_mark: |                    |                    | :white_check_mark:	|
+| fal       |                    |                    | :white_check_mark: |					|
+| ollama    | :white_check_mark: | :white_check_mark: |					   | :white_check_mark:	|
+| openai    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:	|
+| voyageai  |                    | :white_check_mark: |                    |					|
 
 By default, API keys for providers are read from environment variable (`process.env`) following the format `<PROVIDER>_API_KEY` (e.g., `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`).
 

--- a/examples/anthropic-list-models.ts
+++ b/examples/anthropic-list-models.ts
@@ -1,0 +1,6 @@
+import { anthropic } from "../src";
+
+const job = anthropic().listModels();
+const result = await job.run();
+
+console.log(result);

--- a/examples/ollama-list-models.ts
+++ b/examples/ollama-list-models.ts
@@ -1,0 +1,6 @@
+import { ollama } from "../src";
+
+const job = ollama().listModels();
+const result = await job.run();
+
+console.log(result);

--- a/examples/openai-list-models.ts
+++ b/examples/openai-list-models.ts
@@ -1,0 +1,6 @@
+import { openai } from "../src";
+
+const job = openai().listModels();
+const result = await job.run();
+
+console.log(result);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export * from "./jobs/utils";
 export * from "./jobs/chat";
 export * from "./jobs/embedding";
 export * from "./jobs/image";
+export * from "./jobs/models";
 
 export * from "./providers/anthropic";
 export * from "./providers/fal";

--- a/src/jobs/job.ts
+++ b/src/jobs/job.ts
@@ -12,6 +12,7 @@ export interface AIJob {
   provider: AIJobProvider;
   options?: any;
   chat?: any;
+  models?: any;
   embedding?: any;
   image?: any;
 }
@@ -24,7 +25,7 @@ export interface AIProviderOptions {
 export class Job {
   provider!: AIJobProvider;
   options!: AIProviderOptions;
-  model!: string;
+  model?: string;
   params: any;
 
   makeRequest?: () => Request;

--- a/src/jobs/load.ts
+++ b/src/jobs/load.ts
@@ -26,6 +26,8 @@ export function load(obj: AIJob): Job {
 
   if (obj.chat && "chat" in provider) {
     return provider.chat(obj.chat.model)._setParams(obj.chat.params);
+  } else if (obj.models && "listModels" in provider) {
+	return provider.listModels()._setParams(obj.models.params);
   } else if (obj.image && "image" in provider) {
     return provider.image(obj.image.model)._setParams(obj.image.params);
   } else if (obj.embedding && "embedding" in provider) {

--- a/src/jobs/models.ts
+++ b/src/jobs/models.ts
@@ -1,0 +1,13 @@
+import { Job } from "./job";
+
+export class ListModelsJob extends Job {
+  constructor() {
+	super();
+	this.params = {};
+  }
+
+  dump() {
+    const obj = super.dump();
+    return { ...obj, models: { params: this.params } };
+  }
+}

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -1,4 +1,5 @@
 import { ChatJob, convertMessages } from "../jobs/chat";
+import { ListModelsJob } from "../jobs/models";
 import type { AIProviderOptions } from "../jobs/job";
 
 export function anthropic(options?: AIProviderOptions) {
@@ -9,6 +10,9 @@ export function anthropic(options?: AIProviderOptions) {
     chat(model: string) {
       return new AnthropicChatJob(options, model);
     },
+    listModels() {
+      return new AnthropicListModelsJob(options);
+    }
   };
 }
 
@@ -42,6 +46,32 @@ export class AnthropicChatJob extends ChatJob {
       method: "POST",
       headers: headers,
       body: JSON.stringify(requestParams),
+    });
+  };
+
+  handleResponse = async (response: Response) => {
+    const json = await response.json();
+    return json;
+  };
+}
+
+export class AnthropicListModelsJob extends ListModelsJob {
+  constructor(options: AIProviderOptions) {
+    super();
+    this.provider = "anthropic";
+    this.options = options;
+  }
+
+  makeRequest = () => {
+    const headers = {
+      "anthropic-version": "2023-06-01",
+      "x-api-key": this.options.apiKey!,
+      "Content-Type": "application/json",
+    } as any;
+
+    return new Request("https://api.anthropic.com/v1/models", {
+      method: "GET",
+      headers: headers,
     });
   };
 

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -1,4 +1,5 @@
 import { ChatJob, convertMessages } from "../jobs/chat";
+import { ListModelsJob } from "../jobs/models";
 import { EmbeddingJob } from "../jobs/embedding";
 import type { AIProviderOptions } from "../jobs/job";
 
@@ -8,6 +9,9 @@ export function ollama(options?: AIProviderOptions) {
   return {
     chat(model: string) {
       return new OllamaChatJob(options, model);
+    },
+    listModels() {
+      return new OllamaListModelsJob(options);
     },
     embedding(model: string) {
       return new OllamaEmbeddingJob(options, model);
@@ -33,6 +37,23 @@ export class OllamaChatJob extends ChatJob {
         stream: false,
       }),
     });
+  };
+
+  handleResponse = async (response: Response) => {
+    const json = await response.json();
+    return json;
+  };
+}
+
+export class OllamaListModelsJob extends ListModelsJob {
+  constructor(options: AIProviderOptions) {
+    super();
+    this.provider = "ollama";
+    this.options = options;
+  }
+
+  makeRequest = () => {
+    return new Request("http://localhost:11434/api/tags", { method: "GET" });
   };
 
   handleResponse = async (response: Response) => {

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -4,6 +4,7 @@ import zodToJsonSchema from "zod-to-json-schema";
 import { ChatJob, convertMessages } from "../jobs/chat";
 import { EmbeddingJob } from "../jobs/embedding";
 import { ImageJob } from "../jobs/image";
+import { ListModelsJob } from "../jobs/models";
 import type { AIProviderOptions } from "../jobs/job";
 
 const OPENAI_BASE_URL = "https://api.openai.com/v1";
@@ -19,6 +20,9 @@ export function openai(options?: AIProviderOptions) {
   return {
     chat(model: string) {
       return new OpenAIChatJob(options, model);
+    },
+    listModels() {
+      return new OpenAIListModelsJob(options);
     },
     image(model: string) {
       return new OpenAIImageJob(options, model);
@@ -218,6 +222,30 @@ export class OpenAIChatJob extends ChatJob {
       }
       return { text: content };
     }
+  };
+}
+
+
+export class OpenAIListModelsJob extends ListModelsJob {
+  constructor(options: AIProviderOptions) {
+    super();
+    this.provider = "openai";
+    this.options = options
+  }
+
+  makeRequest = () => {
+    const baseURL = this.options.baseURL || OPENAI_BASE_URL;
+    return new Request(`${baseURL}/models`, {
+      headers: {
+        Authorization: `Bearer ${this.options.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      method: "GET"
+    });
+  };
+
+  handleResponse = async (response: Response) => {
+    return await response.json();
   };
 }
 

--- a/test/__snapshots__/listModels.test.ts.snap
+++ b/test/__snapshots__/listModels.test.ts.snap
@@ -1,0 +1,50 @@
+// Bun Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`listModels 1`] = `
+{
+  "body": "",
+  "headers": {
+    "authorization": "Bearer <key>",
+    "content-type": "application/json",
+  },
+  "method": "GET",
+  "url": "https://api.openai.com/v1/models",
+}
+`;
+
+exports[`listModels 2`] = `
+{
+  "body": "",
+  "headers": {
+    "anthropic-version": "2023-06-01",
+    "content-type": "application/json",
+    "x-api-key": "<key>",
+  },
+  "method": "GET",
+  "url": "https://api.anthropic.com/v1/models",
+}
+`;
+
+exports[`dump 1`] = `
+{
+  "models": {
+    "params": {},
+  },
+  "options": {
+    "apiKey": "<key>",
+  },
+  "provider": "openai",
+}
+`;
+
+exports[`dump 2`] = `
+{
+  "models": {
+    "params": {},
+  },
+  "options": {
+    "apiKey": "<key>",
+  },
+  "provider": "anthropic",
+}
+`;

--- a/test/listModels.test.ts
+++ b/test/listModels.test.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "bun:test";
+import { openai, ollama, anthropic, requestObject, load } from "../src";
+
+const jobs = [
+//   ollama().listModels(),
+  openai({ apiKey: "<key>" }).listModels(),
+  anthropic({ apiKey: "<key>" }).listModels()
+];
+
+test("listModels", async () => {
+  for (const job of jobs) {
+	expect(
+	  await requestObject(job.makeRequest())
+	).toMatchSnapshot();
+  }
+});
+
+test("dump", () => {
+  for (const job of jobs) {
+	expect(job.dump()).toMatchSnapshot();
+  }
+});
+
+test("load", async () => {
+  for (const job of jobs) {
+	const req1 = await requestObject(load(job.dump()).makeRequest!());
+	const req2 = await requestObject(job.makeRequest());
+	expect(req1).toEqual(req2);
+  }
+});


### PR DESCRIPTION
This change adds a simple listModels() function to openai, ollama and anthropic. I believe I have followed your conventions to the letter, creating a new `ListModelsJob` class, a new test, and examples to show how to use this function. I have also updated the readme to show which clients support this new listModels function. 

All tests are passing. 

```ts
// openai-list-models.ts
import { openai } from "../src";

const job = openai().listModels();
const result = await job.run();

console.log(result);
```

I am using your library in another project of mine because it is useful and well-organized, but I needed this endpoint for these three clients. 